### PR TITLE
Fix failures caused by external changes

### DIFF
--- a/lib/Data/Pretty.pm
+++ b/lib/Data/Pretty.pm
@@ -1,4 +1,4 @@
-use MONKEY_TYPING;
+use MONKEY-TYPING;
 
 augment class Hash {
     multi method gist is default {
@@ -13,7 +13,7 @@ augment class Hash {
 }
 
 augment class Array {
-    method gist {
+    multi method gist is default {
         '[' ~ $.map(*.gist).join(', ') ~ ']'
     }
 }
@@ -24,20 +24,14 @@ augment class List {
     }
 }
 
-augment class Parcel {
-    multi method gist is default {
-        '(' ~ $.map(*.gist).join(', ') ~ ')'
-    }
-}
-
 augment class Sub {
-    method gist {
+    multi method gist is default {
         '&' ~ ($.name || '<anon>')
     }
 }
 
 augment class Regex {
-    method gist {
+    multi method gist is default {
         '<regex>'
     }
 }

--- a/t/pretty.t
+++ b/t/pretty.t
@@ -10,8 +10,8 @@ is (1, 2, 3).gist, '(1, 2, 3)', "pretty parcels";
 is list(1, 2, 3).gist, '(1, 2, 3)', "pretty list() parcels";
 
 # hashes
-is { foo => 2 }.gist, '{"foo" => 2}', "pretty hashes";
-is hash("foo", 2).gist, '{"foo" => 2}', "pretty hash() hashes";
+is { foo => 2 }.gist, '{foo => 2}', "pretty hashes";
+is hash("foo", 2).gist, '{foo => 2}', "pretty hash() hashes";
 
 # subs
 is sub foo {}.gist, '&foo', "pretty subs";
@@ -20,4 +20,4 @@ is sub {}.gist, '&<anon>', "pretty anon subs";
 # regexes
 is /abc/.gist, '<regex>', "pretty regexes";
 
-done;
+done-testing;


### PR DESCRIPTION
Explicitly override gists with default multis.
Parcel is no more, no longer try to augment it.
Tests updated to reflect default gist on Pairs no longer puts key in quotes.
